### PR TITLE
Configurable port for running the demo service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:1.17-alpine as builder
-
 WORKDIR /source
 COPY . /source
 
@@ -7,9 +6,9 @@ RUN go mod download
 RUN go build -v -o prometheus_demo_service .
 
 FROM        alpine:3
+ARG PORT_ARG=8080
+ENV PORT=${PORT_ARG}
 MAINTAINER  Julius Volz <julius.volz@gmail.com>
-
 COPY --from=builder /source/prometheus_demo_service  /bin/prometheus_demo_service
-
-EXPOSE     8080
+EXPOSE     ${PORT}
 ENTRYPOINT [ "/bin/prometheus_demo_service" ]

--- a/deployment/prometheusdemoservice.yaml
+++ b/deployment/prometheusdemoservice.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheusdemoservice-deployment
+spec:
+  selector:
+    matchLabels:
+      app: prometheusdemoservice
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: prometheusdemoservice
+    spec:
+      containers:
+        - name: prometheusdemoservice1
+          image: sbatati/demoprom:v1
+          env:
+            - name: PORT
+              value: "8080"
+          ports:
+            - containerPort: 8080
+        - name: prometheusdemoservice2
+          image: sbatati/demoprom:v1
+          env:
+            - name: PORT
+              value: "8081"
+          ports:
+            - containerPort: 8081
+        - name: prometheusdemoservice3
+          image: sbatati/demoprom:v1
+          env:
+            - name: PORT
+              value: "8082"
+          ports:
+            - containerPort: 8082

--- a/main.go
+++ b/main.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -45,6 +48,11 @@ func main() {
 		}
 		handleAPI(w, r)
 	})
+	if value, ok := os.LookupEnv("PORT"); ok && len(value) > 0 {
+		value = fmt.Sprintf(":%s", strings.TrimLeft(value, ":"))
+		addr = &value
+	}
+	fmt.Println("Started listening on port: ", strings.TrimLeft(*addr, ":"))
 	http.Handle("/metrics", promhttp.Handler())
 
 	go http.ListenAndServe(*addr, nil)


### PR DESCRIPTION
* Added new env variable `PORT` that can be used to specify the port number used to expose the metrics
* Created a new deployment file as an example of running the demo service in kubernetes using a pod with different containers running on different ports that can be scraped (following the way describe in the DO aricle)
* These changes should not affect or break any of the existing features so `listen-address` should still take precedence over the new env variable feature